### PR TITLE
refactor: Fixed alertContainerSelector path

### DIFF
--- a/src/main/alert/get-alert-container.ts
+++ b/src/main/alert/get-alert-container.ts
@@ -1,4 +1,4 @@
-const alertContainerSelector = 'ul.c746cc21.list.ma0.pa0.tr.z-999'
+const alertContainerSelector = '#app > div > div.cf325dbd.list.ma0.pa0.tr.z-999'
 
 export const getAlertContainer = (): HTMLDivElement => {
   const container = document.querySelector<HTMLDivElement>(

--- a/src/main/alert/get-alert-container.ts
+++ b/src/main/alert/get-alert-container.ts
@@ -1,4 +1,4 @@
-const alertContainerSelector = '#app > div > div.cf325dbd.list.ma0.pa0.tr.z-999'
+const alertContainerSelector = '.list.ma0.pa0.tr.z-999'
 
 export const getAlertContainer = (): HTMLDivElement => {
   const container = document.querySelector<HTMLDivElement>(


### PR DESCRIPTION
Hey!

This pull request include a fix because there was an issue where the alert container selector was not found because it simply didn't exist. I assume npmjs made some changes to their website, anyways I changed the selector path to the correct path and tested the extension and everything seems to be work again.

I also tried to follow the commit message syntax by looking at the other commits so I hope I did it correctly :)