### PR TITLE
fix: bun dev dependency button uses incorrect flag

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -60,7 +60,7 @@ export const typeConfig: Configs = [
   },
   {
     element: 'button',
-    value: 'bun install -D',
+    value: 'bun install -d',
   },
   {
     element: 'button',


### PR DESCRIPTION
To install a package as `devDependency` in `bun` we need to use a `-d` instead of `-D`. Using `-D` does nothing and simply adds the package to regular dependencies.

It's kinda annoying to copy the command from nopy, then edit the `-D` out with `-d` to install as dev dependency for Bun.

As per it's CLI help message 👇 

![Screenshot 2023-09-16 at 1 49 17 PM](https://github.com/ntwigs/nopy/assets/24322511/25c67a7d-2290-4847-909e-64a43a65675f)

Thank you 😀 